### PR TITLE
Add Template for Prometheus URL

### DIFF
--- a/charts/tembo/templates/dataplane-webserver/_helpers.tpl
+++ b/charts/tembo/templates/dataplane-webserver/_helpers.tpl
@@ -60,3 +60,18 @@ Create the name of the service account to use
 {{- default "default" .Values.dataplaneWebserver.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/* Prometheus Service Prefix */}}
+{{- define "dataplaneWebserver.prometheusServicePrefix" -}}
+{{- printf "%s-kube-prometheus-stack" .Release.Name | trunc 26 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+{{- end }}
+
+{{/*
+Prometheus URL
+*/}}
+{{- define "dataplaneWebserver.prometheusUrl" -}}
+{{- printf "http://%s-prometheus.%s.svc.cluster.local:9090" (include "dataplaneWebserver.prometheusServicePrefix" .) .Release.Namespace }}
+{{- end }}

--- a/charts/tembo/templates/dataplane-webserver/_helpers.tpl
+++ b/charts/tembo/templates/dataplane-webserver/_helpers.tpl
@@ -61,12 +61,11 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{/* Prometheus Service Prefix */}}
+{{/*
+Prometheus Service Prefix
+*/}}
 {{- define "dataplaneWebserver.prometheusServicePrefix" -}}
 {{- printf "%s-kube-prometheus-stack" .Release.Name | trunc 26 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
 {{- end }}
 
 {{/*

--- a/charts/tembo/templates/dataplane-webserver/deployment.yaml
+++ b/charts/tembo/templates/dataplane-webserver/deployment.yaml
@@ -41,6 +41,8 @@ spec:
           env:
           - name: RUST_LOG
             value: {{ .Values.dataplaneWebserver.logLevel }}
+          - name: PROMETHEUS_URL
+            value: {{ include "dataplaneWebserver.prometheusUrl" . }}
           {{- if .Values.dataplaneWebserver.env }}{{ .Values.dataplaneWebserver.env | default list | toYaml | nindent 10 }}{{- end }}
           securityContext:
             {{- toYaml .Values.dataplaneWebserver.securityContext | nindent 12 }}


### PR DESCRIPTION
Add template for prometheus URL. This allows us to deploy the monitoring stack and tembo application as one helm release.