### PR TITLE
Allow for defining Affinities, NodeSelectors and Tolerations

### DIFF
--- a/charts/tembo/templates/cp-webserver/configmap.yaml
+++ b/charts/tembo/templates/cp-webserver/configmap.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "cpWebserver.fullname" . }}-affinity
+  labels:
+    {{- include "cpWebserver.labels" . | nindent 4 }}
+data:
+  affinity.json: |
+    {{ .Values.postgresPodScheduling.affinity | toJson }}
+  node-selector.json: |
+    {{ .Values.postgresPodScheduling.nodeSelector | toJson }}
+  tolerations.json: |
+    {{ .Values.postgresPodScheduling.tolerations | toJson }}

--- a/charts/tembo/templates/cp-webserver/deployment.yaml
+++ b/charts/tembo/templates/cp-webserver/deployment.yaml
@@ -72,6 +72,15 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.cpWebserver.resources | nindent 12 }}
+          volumeMounts:
+            - name: pod-scheduling-volume
+              mountPath: /etc/pod-scheduling
+      volumes:
+        - name: pod-scheduling-volume
+          configMap:
+            # Provide the name of the ConfigMap containing the files you want
+            # to add to the container
+            name: {{ include "cpWebserver.fullname" . }}-affinity
       {{- with .Values.cpWebserver.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/tembo/templates/cp-webserver/deployment.yaml
+++ b/charts/tembo/templates/cp-webserver/deployment.yaml
@@ -78,8 +78,6 @@ spec:
       volumes:
         - name: pod-scheduling-volume
           configMap:
-            # Provide the name of the ConfigMap containing the files you want
-            # to add to the container
             name: {{ include "cpWebserver.fullname" . }}-affinity
       {{- with .Values.cpWebserver.nodeSelector }}
       nodeSelector:

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -279,7 +279,7 @@ cpService:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "release-24.2.0"
+    tag: "release-24.2.1"
     pullPolicy: IfNotPresent
 
   resources:
@@ -348,7 +348,7 @@ cpWebserver:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "release-24.2.0"
+    tag: "release-24.2.1"
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults
@@ -414,7 +414,7 @@ cpReconciler:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "release-24.2.0"
+    tag: "release-24.2.1"
     pullPolicy: IfNotPresent
 
   resources:
@@ -485,7 +485,7 @@ cpMetricsWatcher:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "release-24.2.0"
+    tag: "release-24.2.1"
     pullPolicy: IfNotPresent
 
   resources:

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -2,6 +2,12 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# Set affinities and tolerations for all Postgres pods
+postgresPodScheduling:
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+
 conductor:
   logLevel: info
 
@@ -272,7 +278,7 @@ cpService:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "7b85118"
+    tag: "8e0579c"
     pullPolicy: IfNotPresent
 
   resources:
@@ -341,7 +347,7 @@ cpWebserver:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "7b85118"
+    tag: "8e0579c"
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults
@@ -407,7 +413,7 @@ cpReconciler:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "7b85118"
+    tag: "8e0579c"
     pullPolicy: IfNotPresent
 
   resources:
@@ -478,7 +484,7 @@ cpMetricsWatcher:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "7b85118"
+    tag: "8e0579c"
     pullPolicy: IfNotPresent
 
   resources:

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -279,7 +279,7 @@ cpService:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "affinity-0.0.5"
+    tag: "release-24.2.0"
     pullPolicy: IfNotPresent
 
   resources:
@@ -348,7 +348,7 @@ cpWebserver:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "affinity-0.0.5"
+    tag: "release-24.2.0"
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults
@@ -414,7 +414,7 @@ cpReconciler:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "affinity-0.0.5"
+    tag: "release-24.2.0"
     pullPolicy: IfNotPresent
 
   resources:
@@ -485,7 +485,7 @@ cpMetricsWatcher:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "affinity-0.0.5"
+    tag: "release-24.2.0"
     pullPolicy: IfNotPresent
 
   resources:

--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -2,7 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Set affinities and tolerations for all Postgres pods
+# Set affinity, nodeSelector or tolerations for all Postgres pods. More information at
+# https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 postgresPodScheduling:
   affinity: {}
   nodeSelector: {}
@@ -278,7 +279,7 @@ cpService:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "8e0579c"
+    tag: "affinity-0.0.5"
     pullPolicy: IfNotPresent
 
   resources:
@@ -347,7 +348,7 @@ cpWebserver:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "8e0579c"
+    tag: "affinity-0.0.5"
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults
@@ -413,7 +414,7 @@ cpReconciler:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "8e0579c"
+    tag: "affinity-0.0.5"
     pullPolicy: IfNotPresent
 
   resources:
@@ -484,7 +485,7 @@ cpMetricsWatcher:
 
   image:
     repository: quay.io/coredb/cp-service
-    tag: "8e0579c"
+    tag: "affinity-0.0.5"
     pullPolicy: IfNotPresent
 
   resources:


### PR DESCRIPTION
This feature allows for setting pod scheduling constraints (affinity, node selctor, toleration) via helm values. These pod scheduling constraints are applied to all Postgres instance pods.

The values passed via helm are written to a ConfigMap and mounted to  `cp-webserver` where they are read and applied in the code.

Examples values:
```
tembo:
  postgresPodScheduling:
    affinity:
      nodeAffinity:
        requiredDuringSchedulingIgnoredDuringExecution:
          nodeSelectorTerms:
          - matchExpressions:
            - key: tembo.io
              operator: In
              values:
              - "true"
    tolerations:
      - key: tembo
        operator: Equal
        value: enabled
        effect: NoSchedule
    nodeSelector:
      tembo.io: "true"
```