### PR TITLE
Set `SELF_HOSTED` true for cp-webserver

### DIFF
--- a/charts/tembo/templates/cp-webserver/deployment.yaml
+++ b/charts/tembo/templates/cp-webserver/deployment.yaml
@@ -57,6 +57,8 @@ spec:
             value: {{ .Values.cpWebserver.logLevel }}
           - name: DEFAULT_CONTAINER_REGISTRY
             value: quay.io/tembo
+          - name: SELF_HOSTED
+            value: 'true'
           {{- if .Values.cpWebserver.env }}{{ .Values.cpWebserver.env | default list | toYaml | nindent 10 }}{{- end }}
           securityContext:
             {{- toYaml .Values.cpWebserver.securityContext | nindent 12 }}


### PR DESCRIPTION
This will always be true, so we can add it to the `cp-webserver` deployment yaml.