### PR TITLE
Update `temboUI.env` type

### DIFF
--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -650,4 +650,4 @@ temboUI:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  env: {}
+  env: []


### PR DESCRIPTION
Update `temboUI.env` type to `[]`. This resolves warning messages we see on installation and upgrade:
```
❯ helm install tembo . -f ent-test.yaml --namespace tembo
coalesce.go:286: warning: cannot overwrite table with non table for tembo.tembo.temboUI.env (map[])
coalesce.go:286: warning: cannot overwrite table with non table for tembo.tembo.temboUI.env (map[])
coalesce.go:286: warning: cannot overwrite table with non table for tembo.tembo.temboUI.env (map[])

```