### PR TITLE
Revert tembo-ui image tag to aed9151

### DIFF
--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -616,7 +616,7 @@ temboUI:
 
   image:
     repository: quay.io/tembo/mahout-ui
-    tag: bd5b732
+    tag: aed9151
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults


### PR DESCRIPTION
Current image tag requires control-plane changes not yet in the project. Reverting to previous image while we plan to add relevant changes.