### PR TITLE
Add static `temboUI` env vars to deployment template

### DIFF
--- a/charts/tembo/templates/tembo-ui/deployment.yaml
+++ b/charts/tembo/templates/tembo-ui/deployment.yaml
@@ -39,6 +39,20 @@ spec:
           env:
           - name: RUST_LOG
             value: {{ .Values.temboUI.logLevel }}
+          - name: INTERCOM_SECRET
+            value: "placeholder-value"
+          - name: NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY
+            value: "placeholder-value"
+          - name: ORB_SECRET_KEY
+            value: "placeholder-value"
+          - name: NEXT_PUBLIC_POSTHOG_KEY
+            value: "placeholder-value"
+          - name: NEXT_PUBLIC_POSTHOG_HOST
+            value: "placeholder-value"
+          - name: NEXT_PUBLIC_BILLING
+            value: "false"
+          - name: NEXT_PUBLIC_SPOT
+            value: "false"
           {{- if .Values.temboUI.env }}{{ .Values.temboUI.env | default list | toYaml | nindent 10 }}{{- end }}
           securityContext:
             {{- toYaml .Values.temboUI.securityContext | nindent 12 }}


### PR DESCRIPTION
Add the following `temboUI` environment variables to deployment template as they will always be false for now:
- `NEXT_PUBLIC_BILLING`
- `NEXT_PUBLIC_SPOT`

There are a handful of environment variables that we don't use, but are required by the UI image. Adding a temporary placeholder value for these:
- `INTERCOM_SECRET`
- `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY`
- `ORB_SECRET_KEY`
- `NEXT_PUBLIC_POSTHOG_KEY`
- `NEXT_PUBLIC_POSTHOG_HOST`

Moving these to the deployment template simplifies the installation process.