### PR TITLE
Bump UI image to 5cb29ce

### DIFF
--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -616,7 +616,7 @@ temboUI:
 
   image:
     repository: quay.io/tembo/mahout-ui
-    tag: 19ef577
+    tag: 5cb29ce
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults


### PR DESCRIPTION
We had previously used a custom built image to get around metrics URL issues. Bumping UI image to include those changes.