### PR TITLE
Monitoring Enabled by Default

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -1,6 +1,6 @@
 global:
   temboEnabled: true
-  monitoringEnabled: false
+  monitoringEnabled: true
   conductorEnabled: false
   traefikEnabled: true
   baseDomain: ~


### PR DESCRIPTION
All sub-charts should be enabled by default with the ability to disable them if desired. Default monitoringEnabled to `true`.