### PR TITLE
Template API and Metrics Base URLs

### DIFF
--- a/charts/tembo/templates/tembo-ui/_helpers.tpl
+++ b/charts/tembo/templates/tembo-ui/_helpers.tpl
@@ -71,3 +71,29 @@ Define IngressClass name
 {{- "traefik" }}
 {{- end }}
 {{- end }}
+
+{{/*
+Define API Base URL
+*/}}
+{{- define "temboUI.apiBaseUrl" -}}
+{{- if .Values.global.tlsEnabled }}
+- name: NEXT_PUBLIC_API_BASE_URL_V1
+  value: {{- printf " https://api.%s/api/v1" .Values.global.baseDomain }}
+{{- else }}
+- name: NEXT_PUBLIC_API_BASE_URL_V1
+  value: {{- printf " http://api.%s/api/v1" .Values.global.baseDomain }}
+{{- end }}
+{{- end }}
+
+{{/*
+Define Metrics Base URL
+*/}}
+{{- define "temboUI.metricsBaseUrl" -}}
+{{- if .Values.global.tlsEnabled }}
+- name: NEXT_PUBLIC_METRICS_BASE_URL
+  value: {{- printf " https://dataplane.%s" .Values.global.baseDomain }}
+{{- else }}
+- name: NEXT_PUBLIC_METRICS_BASE_URL
+  value: {{- printf " http://dataplane.%s" .Values.global.baseDomain }}
+{{- end }}
+{{- end }}

--- a/charts/tembo/templates/tembo-ui/deployment.yaml
+++ b/charts/tembo/templates/tembo-ui/deployment.yaml
@@ -53,6 +53,8 @@ spec:
             value: "false"
           - name: NEXT_PUBLIC_SPOT
             value: "false"
+          {{- include "temboUI.apiBaseUrl" . | nindent 10 }}
+          {{- include "temboUI.metricsBaseUrl" . | nindent 10}}
           {{- if .Values.temboUI.env }}{{ .Values.temboUI.env | default list | toYaml | nindent 10 }}{{- end }}
           securityContext:
             {{- toYaml .Values.temboUI.securityContext | nindent 12 }}


### PR DESCRIPTION
We currently need to pass the following environment variables to temboUI:
```
    env:
      - name: NEXT_PUBLIC_API_BASE_URL_V1
        value: "http://api.gcp.tembo-software.com/api/v1"
      - name: NEXT_PUBLIC_METRICS_BASE_URL
        value: "http://dataplane.gcp.tembo-software.com"
```

This PR templates these values, reducing the input values the user needs to define.