### PR TITLE
Bump UI image to support intercom integration

### DIFF
--- a/charts/tembo/values.yaml
+++ b/charts/tembo/values.yaml
@@ -616,7 +616,7 @@ temboUI:
 
   image:
     repository: quay.io/tembo/mahout-ui
-    tag: 5cb29ce
+    tag: e95ed19
     pullPolicy: IfNotPresent
 
   # We should reconfigure the defaults


### PR DESCRIPTION
Bump UI image tag to `e95ed19`, which includes support for passing `NEXT_PUBLIC_INTERCOM_APP_ID`.